### PR TITLE
Add config/routes.rb to gemspec files

### DIFF
--- a/imgproxy-rails.gemspec
+++ b/imgproxy-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.license = "MIT"
 
-  s.files = Dir.glob("lib/**/*") + Dir.glob("bin/**/*") + %w[README.md LICENSE.txt CHANGELOG.md]
+  s.files = Dir.glob("lib/**/*") + Dir.glob("bin/**/*") + Dir.glob("config/**/*") + %w[README.md LICENSE.txt CHANGELOG.md]
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.7"
 


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Fix `config/routes.rb` missing in gem package.

Without routes, it will raise `undefined method 'imgproxy_active_storage_url'` exception

## What changes did you make? (overview)

Add `Dir.glob("config/**/*")` in gemspec.

## Is there anything you'd like reviewers to focus on?

No logic change, just config.

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
